### PR TITLE
Dev

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -36,6 +36,9 @@ export default function factory(localforage) {
 
     async function get(bin, key, validate = true) {
         const isValid = validate && cacheBins[bin] ? await cacheBins[EXPIRE_BIN].getItem(getExpireKey(bin, key)) > Date.now() : true;
+        if (!isValid) {
+            await cacheBins[EXPIRE_BIN].removeItem(getExpireKey(bin, key));
+        }
         return isValid ? await cacheBins[bin].getItem(key) : null; // localForage return null if item doesn't exist
     }
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -42,7 +42,7 @@ export default function factory(localforage) {
         return isValid ? await cacheBins[bin].getItem(key) : null; // localForage return null if item doesn't exist
     }
 
-    async function set(bin, key, data, expire = Infinity) {
+    async function set(bin, key, data, expire = Number.MAX_SAFE_INTEGER) {
         return await Promise.all([
             cacheBins[EXPIRE_BIN].setItem(getExpireKey(bin, key), Date.now() + Number(expire)),
             cacheBins[bin].setItem(key, data)

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 import factory from './factory';
-import localforage from 'localforage/dist/localforage.nopromises';
+import localforage from 'localforage/src/localforage';
 
 export default factory(localforage);


### PR DESCRIPTION
*  build(deps): user unbuilt version of localforage			d0b9f71
*  fix: clean up __expire__ table if entry is expired			128fea8
*  fix: cache still expires by default  (use serialize-friendly Number.MAX_SAFE_INTEGER instead of Infinity)